### PR TITLE
Improve TQL logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Model Context Protocol (MCP) server that enables AI assistants (Claude, Cursor, 
 - **API Compatibility** - automatic handling of payload format differences (flat vs wrapped)
 - **Run Management** - status transitions via `status_event` parameter
 - **TQL-Only Search** - `tests_list/tests_search` and `runs_list/runs_search` use `tql` as the single search/filter input
-- **Safe TQL Guidance** - prefer documented expressions like `priority == high`, `state == automated`, `size == 5`, `size > 1`; do not guess undocumented TQL syntax; fall back only when the API rejects the TQL expression or the needed field is not supported
+- **Built-In TQL Reference** - MCP tool descriptions include exact TQL fields, syntax, and examples for agents
 
 ## Quick Start
 
@@ -135,7 +135,7 @@ Add this config to `opencode.json` in your project root, or to `~/.config/openco
 ```json
 {
   "name": "tests_list",
-  "arguments": { "page": 1, "per_page": 50, "tql": "priority == high" }
+  "arguments": { "page": 1, "per_page": 50, "tql": "priority == 'high'" }
 }
 ```
 
@@ -240,8 +240,8 @@ NODE_EXTRA_CA_CERTS=/path/to/company-root-ca.pem testomatio-mcp --token <TOKEN> 
 - **Run Status** - Use `runs_update` with `status_event` for transitions (finish, launch, rerun, etc.)
 - **Search** - No dedicated `/search` endpoints. MCP search tools delegate to list tools; for `tests` and `runs` the MCP interface is intentionally simplified to `tql`, while other entities stay closer to Public API v2 filters
 - **TQL** - Use `tql` as the single search/filter input for `tests_list/tests_search` and `runs_list/runs_search`
-- **TQL Safety** - Prefer documented expressions like `priority == high`, `state == automated`, `size == 5`, `size > 1`; do not invent tag-style or free-text syntax unless it was verified
-- **Fallback Rule** - For `tests` and `runs`, try `tql` first. Use other tools or extra analysis only after the API rejects the TQL expression or the needed field is not supported by TQL
+- **TQL Syntax** - For user-facing syntax details and more examples, see the official TQL docs: https://docs.testomat.io/advanced/tql/
+- **TQL Scope** - The full agent-oriented whitelist of documented fields lives inside MCP tool descriptions for `tests` and `runs`
 - **Issue Linking** - Scoped helpers available: `{entity}_issues_link/unlink`
 
 ## Development

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -47,17 +47,17 @@ Check server status and active configuration.
 
 List all tests in the project with filtering.
 
-Use `tql` first for search/filtering.
-Prefer known-safe expressions such as `priority == high` and `state == automated`.
-Do not guess undocumented TQL syntax.
-Fall back to other tools or extra analysis only if the API rejects the TQL expression or the needed field is not supported by TQL.
+Use `tql` for search/filtering.
+TQL means `Testomat.io Query Language`.
+Use standard TQL syntax such as `==`, `!=`, `in [...]`, `%`, `and`, `or`, `not`, and parentheses.
+For the full syntax and field reference, see the official docs: https://docs.testomat.io/advanced/tql/
 
 **Parameters:**
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
 | page | integer | No | Page number (min: 1) |
 | per_page | integer | No | Items per page (min: 1, max: 100) |
-| tql | string | No | Universal TQL filter for tests. Safe examples: `priority == high`, `state == automated` |
+| tql | string | No | TQL filter for tests. Examples: `priority == 'high'`, `state == 'automated'`, `suite % 'Checkout'` |
 
 **Example:**
 ```json
@@ -66,7 +66,7 @@ Fall back to other tools or extra analysis only if the API rejects the TQL expre
   "arguments": {
     "page": 1,
     "per_page": 50,
-    "tql": "priority == high"
+    "tql": "priority == 'high'"
   }
 }
 ```
@@ -210,10 +210,8 @@ Delete a test.
 
 Search tests (delegates to `tests_list`).
 
-Use `tql` first.
-Prefer known-safe expressions such as `priority == high` and `state == automated`.
-Do not guess undocumented TQL syntax.
-Fall back to other tools or extra analysis only if the API rejects the TQL expression or the needed field is not supported by TQL.
+TQL means `Testomat.io Query Language`.
+Use standard TQL syntax. For the full syntax and field reference, see the official docs: https://docs.testomat.io/advanced/tql/
 
 **Parameters:** Same as `tests_list`
 
@@ -222,7 +220,7 @@ Fall back to other tools or extra analysis only if the API rejects the TQL expre
 {
   "name": "tests_search",
   "arguments": {
-    "tql": "state == automated",
+    "tql": "state == 'automated'",
     "page": 1,
     "per_page": 20
   }
@@ -432,17 +430,17 @@ Same pattern as test issue operations, but for suites.
 
 List all test runs.
 
-Use `tql` first for search/filtering.
-Prefer known-safe expressions such as `size == 5` and `size > 1`.
-Do not guess undocumented TQL syntax.
-Fall back to other tools or extra analysis only if the API rejects the TQL expression or the needed field is not supported by TQL.
+Use `tql` for search/filtering.
+TQL means `Testomat.io Query Language`.
+Use standard TQL syntax such as `==`, `!=`, `>`, `<`, `>=`, `<=`, `in [...]`, `%`, `and`, `or`, `not`, and parentheses.
+For the full syntax and field reference, see the official docs: https://docs.testomat.io/advanced/tql/
 
 **Parameters:**
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
 | page | integer | No | Page number |
 | per_page | integer | No | Items per page |
-| tql | string | No | Universal TQL filter for runs. Safe examples: `size == 5`, `size > 1` |
+| tql | string | No | TQL filter for runs. Examples: `title % 'Manual tests'`, `plan == '{PLAN_ID}'`, `finished and with_defect` |
 
 **Example:**
 ```json
@@ -451,7 +449,7 @@ Fall back to other tools or extra analysis only if the API rejects the TQL expre
   "arguments": {
     "page": 1,
     "per_page": 10,
-    "tql": "size > 1"
+    "tql": "failed and has_test_tag == 'regression'"
   }
 }
 ```
@@ -574,10 +572,22 @@ Delete a run.
 
 Search runs (delegates to `runs_list`).
 
-Use `tql` first.
-Prefer known-safe expressions such as `size == 5` and `size > 1`.
-Do not guess undocumented TQL syntax.
-Fall back to other tools or extra analysis only if the API rejects the TQL expression or the needed field is not supported by TQL.
+TQL means `Testomat.io Query Language`.
+Use standard TQL syntax. For the full syntax and field reference, see the official docs: https://docs.testomat.io/advanced/tql/
+
+**Parameters:** Same as `runs_list`
+
+**Example:**
+```json
+{
+  "name": "runs_search",
+  "arguments": {
+    "tql": "finished and with_defect",
+    "page": 1,
+    "per_page": 20
+  }
+}
+```
 
 ---
 

--- a/src/mcp/definitions/runs.js
+++ b/src/mcp/definitions/runs.js
@@ -1,7 +1,9 @@
+import { RUNS_TQL_INPUT_DESCRIPTION, RUNS_TQL_REFERENCE } from './tql-reference.js';
+
 export const RUNS_TOOLS = [
   {
     "name": "runs_list",
-    "description": "List runs (/api/v2/{project_id}/runs). Use `tql` first for search/filtering. Prefer known-safe expressions such as `size == 5` or `size > 1`. Do not guess undocumented TQL syntax. Fall back to other tools or analysis only if the API rejects the TQL expression or the needed field is not supported by TQL.",
+    "description": `List runs (/api/v2/{project_id}/runs). ${RUNS_TQL_REFERENCE}`,
     "inputSchema": {
       "type": "object",
       "properties": {
@@ -16,7 +18,7 @@ export const RUNS_TOOLS = [
         },
         "tql": {
           "type": "string",
-          "description": "Universal TQL filter for runs. Prefer known-safe expressions like `size == 5` or `size > 1`. Do not guess undocumented syntax. Fall back only if the API rejects the TQL expression or the needed field is not supported by TQL."
+          "description": RUNS_TQL_INPUT_DESCRIPTION
         }
       },
       "additionalProperties": false
@@ -264,7 +266,7 @@ export const RUNS_TOOLS = [
   },
   {
     "name": "runs_search",
-    "description": "Search runs using TQL (delegates to runs_list). Use `tql` first. Prefer known-safe expressions such as `size == 5` or `size > 1`. Do not guess undocumented TQL syntax. Fall back to other tools or analysis only if the API rejects the TQL expression or the needed field is not supported by TQL.",
+    "description": `Search runs using TQL (delegates to runs_list). ${RUNS_TQL_REFERENCE}`,
     "inputSchema": {
       "type": "object",
       "properties": {
@@ -279,7 +281,7 @@ export const RUNS_TOOLS = [
         },
         "tql": {
           "type": "string",
-          "description": "Universal TQL filter for runs. Prefer known-safe expressions like `size == 5` or `size > 1`. Do not guess undocumented syntax. Fall back only if the API rejects the TQL expression or the needed field is not supported by TQL."
+          "description": RUNS_TQL_INPUT_DESCRIPTION
         }
       },
       "additionalProperties": false

--- a/src/mcp/definitions/tests.js
+++ b/src/mcp/definitions/tests.js
@@ -1,7 +1,9 @@
+import { TESTS_TQL_INPUT_DESCRIPTION, TESTS_TQL_REFERENCE } from './tql-reference.js';
+
 export const TESTS_TOOLS = [
   {
     "name": "tests_list",
-    "description": "List tests (/api/v2/{project_id}/tests). Use `tql` first for search/filtering. Prefer known-safe expressions such as `priority == high` or `state == automated`. Do not guess undocumented TQL syntax. Fall back to other tools or analysis only if the API rejects the TQL expression or the needed field is not supported by TQL.",
+    "description": `List tests (/api/v2/{project_id}/tests). ${TESTS_TQL_REFERENCE}`,
     "inputSchema": {
       "type": "object",
       "properties": {
@@ -16,7 +18,7 @@ export const TESTS_TOOLS = [
         },
         "tql": {
           "type": "string",
-          "description": "Universal TQL filter for tests. Prefer known-safe expressions like `priority == high` or `state == automated`. Do not guess undocumented syntax. Fall back only if the API rejects the TQL expression or the needed field is not supported by TQL."
+          "description": TESTS_TQL_INPUT_DESCRIPTION
         }
       },
       "additionalProperties": false
@@ -207,7 +209,7 @@ export const TESTS_TOOLS = [
   },
   {
     "name": "tests_search",
-    "description": "Search tests using TQL (delegates to tests_list). Use `tql` first. Prefer known-safe expressions such as `priority == high` or `state == automated`. Do not guess undocumented TQL syntax. Fall back to other tools or analysis only if the API rejects the TQL expression or the needed field is not supported by TQL.",
+    "description": `Search tests using TQL (delegates to tests_list). ${TESTS_TQL_REFERENCE}`,
     "inputSchema": {
       "type": "object",
       "properties": {
@@ -222,7 +224,7 @@ export const TESTS_TOOLS = [
         },
         "tql": {
           "type": "string",
-          "description": "Universal TQL filter for tests. Prefer known-safe expressions like `priority == high` or `state == automated`. Do not guess undocumented syntax. Fall back only if the API rejects the TQL expression or the needed field is not supported by TQL."
+          "description": TESTS_TQL_INPUT_DESCRIPTION
         }
       },
       "additionalProperties": false

--- a/src/mcp/definitions/tql-reference.js
+++ b/src/mcp/definitions/tql-reference.js
@@ -1,0 +1,105 @@
+const TESTS_TQL_VARIABLES = [
+  'tag',
+  'label',
+  'priority',
+  'issue',
+  'jira',
+  'state',
+  'status',
+  'custom_status',
+  'created_at',
+  'updated_at',
+  'last_run_at',
+  'executed_at',
+  'created_by',
+  'assigned_to',
+  'suite',
+  'test',
+];
+
+const RUNS_TQL_VARIABLES = [
+  'title',
+  'plan',
+  'rungroup',
+  'env',
+  'tag',
+  'label',
+  'jira',
+  'duration',
+  'passed_count',
+  'failed_count',
+  'skipped_count',
+  'automated',
+  'manual',
+  'mixed',
+  'finished',
+  'unfinished',
+  'passed',
+  'failed',
+  'terminated',
+  'published',
+  'private',
+  'archived',
+  'unarchived',
+  'with_defect',
+  'has_defect',
+  'has_test',
+  'has_test_tag',
+  'has_test_label',
+  'has_suite',
+  'has_message',
+  'has_custom_status',
+  'has_assigned_to',
+  'has_retries',
+  'has_test_duration',
+  'has_priority',
+  'created_at',
+  'updated_at',
+  'launched_at',
+  'finished_at',
+];
+
+const TESTS_TQL_EXAMPLES = [
+  "priority == 'high'",
+  "state == 'automated'",
+  "tag in ['smoke', 'stage1'] and status == 'failed'",
+  "suite % 'Checkout'",
+  "test % 'User login'",
+  "created_at < 1.month_ago",
+  "jira in ['JST-1', 'JST-2']",
+];
+
+const RUNS_TQL_EXAMPLES = [
+  "title % 'Manual tests'",
+  "plan == '{PLAN_ID}'",
+  "env in ['Windows', 'Linux']",
+  "failed and has_test_tag == 'regression'",
+  'finished and with_defect',
+  'has_retries > 2',
+  "automated and env == 'Production' and has_message % 'Server Error'",
+  "finished_at >= '2025-07-01' and finished_at <= '2025-07-31' and failed",
+];
+
+const COMMON_TQL_SYNTAX =
+  "Supported syntax includes `==`, `!=`, `>`, `<`, `>=`, `<=`, `in [...]`, `%` for partial text match, `and`, `or`, `not`, and parentheses for grouping. Use quotes for string values, for example `state == 'automated'`.";
+
+export const TESTS_TQL_REFERENCE =
+  `TQL (Testomat.io Query Language) is a string expression passed in \`tql\` to filter tests. ${COMMON_TQL_SYNTAX} ` +
+  `Documented test variables: ${TESTS_TQL_VARIABLES.map((item) => `\`${item}\``).join(', ')}. ` +
+  `Documented examples: ${TESTS_TQL_EXAMPLES.map((item) => `\`${item}\``).join(', ')}. ` +
+  'Do not invent undocumented fields or syntax. If a query fails, simplify it to one documented predicate.';
+
+export const TESTS_TQL_INPUT_DESCRIPTION =
+  `TQL filter for tests. Documented variables: ${TESTS_TQL_VARIABLES.map((item) => `\`${item}\``).join(', ')}. ` +
+  `Examples: ${TESTS_TQL_EXAMPLES.map((item) => `\`${item}\``).join(', ')}.`;
+
+export const RUNS_TQL_REFERENCE =
+  `TQL (Testomat.io Query Language) is a string expression passed in \`tql\` to filter runs. ${COMMON_TQL_SYNTAX} ` +
+  'Runs also support boolean flags without comparison such as `failed`, `finished`, `automated`, or `with_defect`. ' +
+  `Documented run variables: ${RUNS_TQL_VARIABLES.map((item) => `\`${item}\``).join(', ')}. ` +
+  `Documented examples: ${RUNS_TQL_EXAMPLES.map((item) => `\`${item}\``).join(', ')}. ` +
+  'Do not invent undocumented fields or syntax. If a query fails, simplify it to one documented predicate.';
+
+export const RUNS_TQL_INPUT_DESCRIPTION =
+  `TQL filter for runs. Documented variables: ${RUNS_TQL_VARIABLES.map((item) => `\`${item}\``).join(', ')}. ` +
+  `Examples: ${RUNS_TQL_EXAMPLES.map((item) => `\`${item}\``).join(', ')}.`;


### PR DESCRIPTION
Implemented a dedicated agent-facing TQL reference for tests and runs inside MCP tool definitions, including documented fields, supported syntax, and verified query examples. Kept user-facing docs lightweight by removing the full embedded reference and linking to the official TQL documentation instead.