### PR TITLE
Compact JSON serialization, drop null keys

### DIFF
--- a/src/mcp/tool-registry.js
+++ b/src/mcp/tool-registry.js
@@ -8,27 +8,8 @@ import { issueMethods } from './registry/issues.js';
 import { listingMethods } from './registry/listings.js';
 import { payloadMethods } from './registry/payloads.js';
 
-function isEmptyValue(value) {
-  return value === null || value === undefined || value === '';
-}
-
-function stripEmpty(value) {
-  if (Array.isArray(value)) {
-    return value.map(stripEmpty);
-  }
-  if (value && typeof value === 'object') {
-    const result = {};
-    for (const [key, v] of Object.entries(value)) {
-      if (isEmptyValue(v)) continue;
-      result[key] = stripEmpty(v);
-    }
-    return result;
-  }
-  return value;
-}
-
 function formatJson(payload) {
-  return JSON.stringify(stripEmpty(payload));
+  return JSON.stringify(payload);
 }
 
 export class ToolRegistry {

--- a/src/mcp/tool-registry.js
+++ b/src/mcp/tool-registry.js
@@ -8,8 +8,27 @@ import { issueMethods } from './registry/issues.js';
 import { listingMethods } from './registry/listings.js';
 import { payloadMethods } from './registry/payloads.js';
 
+function isEmptyValue(value) {
+  return value === null || value === undefined || value === '';
+}
+
+function stripEmpty(value) {
+  if (Array.isArray(value)) {
+    return value.map(stripEmpty);
+  }
+  if (value && typeof value === 'object') {
+    const result = {};
+    for (const [key, v] of Object.entries(value)) {
+      if (isEmptyValue(v)) continue;
+      result[key] = stripEmpty(v);
+    }
+    return result;
+  }
+  return value;
+}
+
 function formatJson(payload) {
-  return JSON.stringify(payload, null, 2);
+  return JSON.stringify(stripEmpty(payload));
 }
 
 export class ToolRegistry {


### PR DESCRIPTION
## Summary
Serializes all tool responsess as compact single-line JSON instead of pretty-printed, and recursively drops null/undefined/empty-string keys.