### PR TITLE
 Add in-band truncation note when a list result hits per_page

### DIFF
--- a/src/mcp/tool-registry.js
+++ b/src/mcp/tool-registry.js
@@ -16,11 +16,19 @@ function withPagination(payload) {
   if (!Array.isArray(payload.data) || !meta || typeof meta !== 'object') {
     return payload;
   }
-  const perPage = meta.per_page;
-  if (typeof perPage === 'number' && perPage > 0 && payload.data.length >= perPage) {
+  const { total, page, per_page: perPage } = meta;
+  if (
+    typeof total !== 'number' ||
+    typeof page !== 'number' ||
+    typeof perPage !== 'number' ||
+    perPage <= 0
+  ) {
+    return payload;
+  }
+  if (page * perPage < total) {
     return {
       ...payload,
-      _note: `Result hit per_page (${perPage}). More may be available — refine the filter or request the next page.`,
+      _note: `Showing ${payload.data.length} of ${total} (page ${page}). More available — refine the filter or request the next page.`,
     };
   }
   return payload;

--- a/src/mcp/tool-registry.js
+++ b/src/mcp/tool-registry.js
@@ -8,6 +8,24 @@ import { issueMethods } from './registry/issues.js';
 import { listingMethods } from './registry/listings.js';
 import { payloadMethods } from './registry/payloads.js';
 
+function withPagination(payload) {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    return payload;
+  }
+  const meta = payload.meta;
+  if (!Array.isArray(payload.data) || !meta || typeof meta !== 'object') {
+    return payload;
+  }
+  const perPage = meta.per_page;
+  if (typeof perPage === 'number' && perPage > 0 && payload.data.length >= perPage) {
+    return {
+      ...payload,
+      _note: `Result hit per_page (${perPage}). More may be available — refine the filter or request the next page.`,
+    };
+  }
+  return payload;
+}
+
 function formatJson(payload) {
   return JSON.stringify(payload, null, 2);
 }
@@ -23,7 +41,7 @@ export class ToolRegistry {
   }
 
   asText(payload) {
-    return textResponse(formatJson(payload));
+    return textResponse(formatJson(withPagination(payload)));
   }
 
   buildHandlers() {


### PR DESCRIPTION
## Summary

List responses now get an in-band _note when the result fills the page (hits per_page): "Result hit per_page (N). More may be available — refine the filter or request the next page." so the model doesn't treat a partial list as complete.