### PR TITLE
Add project_info MCP tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Model Context Protocol (MCP) server that enables AI assistants (Claude, Cursor, 
   - Issues (global + scoped helpers for tests/suites/runs/testruns/plans)
   - Attachments (scoped helpers for tests/suites/testruns)
   - Requirements (including file uploads from local file paths)
+- **Project Information** - fetch project configuration, metadata, features, and CI profiles
 - **Issue Linking** - link/unlink issues to any resource
 - **API Compatibility** - automatic handling of payload format differences (flat vs wrapped)
 - **Automatic API Sessions** - groups MCP changes in Testomat.io history using API sessions

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,10 +1,11 @@
 # Tools Reference
 
-Complete reference for all 83 MCP tools available in the Testomat.io MCP Server.
+Complete reference for all 84 MCP tools available in the Testomat.io MCP Server.
 
 ## Table of Contents
 
 - [System Tools](#system-tools)
+- [Project Tools](#project-tools)
 - [Test Management](#test-management)
 - [Suite Management](#suite-management)
 - [Run Management](#run-management)
@@ -42,6 +43,22 @@ Check server status and active configuration.
   "apiVersion": "v2"
 }
 ```
+
+---
+
+## Project Tools
+
+### project_info
+
+Get configuration and metadata for the configured project.
+
+**Parameters:** None
+
+**Returns:** Project title and ID, framework, language, status, repository URL,
+timestamps, artifact storage status, environments, labels, tags, subscription,
+enabled features, and CI profiles.
+
+**API Endpoint:** `GET /api/v2/{project_id}/info`
 
 ---
 

--- a/src/mcp/definitions/projects.js
+++ b/src/mcp/definitions/projects.js
@@ -1,0 +1,12 @@
+export const PROJECT_TOOLS = [
+  {
+    name: 'project_info',
+    description:
+      'Get configuration and metadata for the current project (/api/v2/{project_id}/info), including framework, language, environments, labels, tags, subscription features, artifact storage status, and CI profiles.',
+    inputSchema: {
+      type: 'object',
+      properties: {},
+      additionalProperties: false,
+    },
+  },
+];

--- a/src/mcp/registry/handlers.js
+++ b/src/mcp/registry/handlers.js
@@ -82,6 +82,8 @@ export const handlerMethods = {
   },
 
   registerGlobalHandlers(handlers) {
+    handlers.project_info = async () => this.asText(await this.apiClient.get('info'));
+
     handlers.tags_list = async () => this.asText(await this.listTags());
     handlers.tags_get = async ({ tag_id: tagId }) => this.asText(await this.getTagByTitle(tagId));
     handlers.tags_search = async (args = {}) => this.asText(await this.searchTags(args));

--- a/src/mcp/tool-definitions.js
+++ b/src/mcp/tool-definitions.js
@@ -1,4 +1,5 @@
 import { SYSTEM_TOOLS } from './definitions/system.js';
+import { PROJECT_TOOLS } from './definitions/projects.js';
 import { TESTS_TOOLS } from './definitions/tests.js';
 import { SUITES_TOOLS } from './definitions/suites.js';
 import { RUNS_TOOLS } from './definitions/runs.js';
@@ -16,6 +17,7 @@ import { ATTACHMENT_TOOLS } from './definitions/attachments.js';
 
 export const TOOL_DEFINITIONS = [
   ...SYSTEM_TOOLS,
+  ...PROJECT_TOOLS,
   ...TESTS_TOOLS,
   ...SUITES_TOOLS,
   ...RUNS_TOOLS,


### PR DESCRIPTION
 ## Summary

  Adds the project_info MCP tool for retrieving configuration and metadata of the currently configured Testomat.io project.

  The tool uses:

  GET /api/v2/{project_id}/info

  The project ID and authorization token are taken from the existing MCP server configuration.