### PR TITLE
Add missing test state and suite file type enums

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -116,7 +116,7 @@ Create a new test.
 | priority | string | No | One of: `low`, `normal`, `important`, `high`, `critical` |
 | assigned_to | string | No | Assignee ID |
 | code | string | No | Test code/automation reference |
-| state | string | No | Test state |
+| state | string | No | One of: `manual`, `detached`, `automated` |
 | link | array | No | Links to labels, tags, milestones, issues, or jira |
 
 **Link Array Format:**
@@ -167,7 +167,7 @@ Update an existing test.
 | priority | string | No | One of: `low`, `normal`, `important`, `high`, `critical` |
 | assigned_to | string | No | Assignee ID |
 | code | string | No | Test code |
-| state | string | No | Test state |
+| state | string | No | One of: `manual`, `detached`, `automated` |
 | sync | boolean | No | Sync with automation |
 | link | array | No | Link updates |
 
@@ -344,7 +344,7 @@ Create a new suite.
 | description | string | No | Suite description |
 | emoji | string | No | Suite emoji |
 | parent_id | string | No | Parent suite ID |
-| file_type | string | No | File type |
+| file_type | string | No | One of: `file`, `folder` |
 | assigned_to | string | No | Assignee ID |
 | file | string | No | File reference |
 | children | array | No | Child suites |
@@ -366,7 +366,7 @@ Update an existing suite.
 | description | string | No | Description |
 | emoji | string | No | Emoji |
 | parent_id | string | No | Parent suite ID |
-| file_type | string | No | File type |
+| file_type | string | No | One of: `file`, `folder` |
 | assigned_to | string | No | Assignee ID |
 | file | string | No | File reference |
 | children | array | No | Child suites |

--- a/src/mcp/definitions/suites.js
+++ b/src/mcp/definitions/suites.js
@@ -69,7 +69,11 @@ export const SUITES_TOOLS = [
           "type": "string"
         },
         "file_type": {
-          "type": "string"
+          "type": "string",
+          "enum": [
+            "file",
+            "folder"
+          ]
         },
         "assigned_to": {
           "type": "string"
@@ -146,7 +150,11 @@ export const SUITES_TOOLS = [
           "type": "string"
         },
         "file_type": {
-          "type": "string"
+          "type": "string",
+          "enum": [
+            "file",
+            "folder"
+          ]
         },
         "assigned_to": {
           "type": "string"

--- a/src/mcp/definitions/tests.js
+++ b/src/mcp/definitions/tests.js
@@ -75,7 +75,12 @@ export const TESTS_TOOLS = [
           "type": "string"
         },
         "state": {
-          "type": "string"
+          "type": "string",
+          "enum": [
+            "manual",
+            "detached",
+            "automated"
+          ]
         },
         "link": {
           "type": "array",
@@ -158,7 +163,12 @@ export const TESTS_TOOLS = [
           "type": "string"
         },
         "state": {
-          "type": "string"
+          "type": "string",
+          "enum": [
+            "manual",
+            "detached",
+            "automated"
+          ]
         },
         "sync": {
           "type": "boolean"


### PR DESCRIPTION
 ## Summary

  - add `manual`, `detached`, and `automated` enum values for `Test.state`
  - add `file` and `folder` enum values for `Suite.file_type`
  - update MCP tool documentation