### PR TITLE
Pass slim parameter to list API requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ NODE_EXTRA_CA_CERTS=/path/to/company-root-ca.pem testomatio-mcp --token <TOKEN> 
 
 - **Run Status** - Use `runs_update` with `status_event` for transitions (finish, launch, rerun, etc.)
 - **Search/Filter** - No dedicated `/search` endpoints; filtering is done via the `*_list` tools (`tql` for tests and runs, OpenAPI-aligned filters for other entities)
+- **Slim List Responses** - List tools request compact API responses by default and omit heavy entity fields and null values. Pass `verbose: true` to return full objects, or `fields: ["id", "title", "description"]` to return only selected fields. Both options disable the backend `slim=true` request so heavy fields remain available when requested.
 - **TQL** - Use `tql` as the single search/filter input for `tests_list` and `runs_list`
 - **TQL Syntax** - For user-facing syntax details and more examples, see the official TQL docs: https://docs.testomat.io/advanced/tql/
 - **TQL Scope** - TQL parameter descriptions keep the documented field whitelist in-band; call `tql_help` for syntax details and additional examples

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1486,6 +1486,16 @@ All list operations support:
 - `page` (integer, min: 1)
 - `per_page` (integer, min: 1, max: 100)
 
+### List Response Projection
+
+List operations request slim responses from the API by default. Heavy entity fields such as `description` and `code`, duplicate title fields, and null values are omitted from the result.
+
+- `verbose: true` disables the backend slim request and returns full objects.
+- `fields: ["id", "title", "description"]` disables the backend slim request and returns only the selected non-null fields.
+- If both are provided, `verbose: true` takes precedence and returns full objects.
+
+The backend `slim` parameter is managed internally by MCP; callers should use `verbose` or `fields` rather than pass `slim` directly.
+
 ### Issue Linking
 
 Two ways to link issues:

--- a/packages/enterprise/src/analytics.js
+++ b/packages/enterprise/src/analytics.js
@@ -4,6 +4,7 @@ import {
   ANALYTICS_TESTS_TQL_INPUT_DESCRIPTION,
   ANALYTICS_TESTS_TQL_REFERENCE,
   TOOL_DEFINITIONS,
+  backendSlimQuery,
   slimList,
   withListOptions,
 } from './load-core.js';
@@ -139,7 +140,7 @@ export const ENTERPRISE_TOOL_DEFINITIONS = [
 export function registerAnalyticsHandlers(handlers) {
   handlers.analytics_tests = async (args = {}) =>
     this.asText(
-      slimList(await analyticsTests.call(this, args), {
+      slimList(await analyticsTests.call(this, { ...args, ...backendSlimQuery(args) }), {
         verbose: args.verbose,
         fields: args.fields,
         entity: 'analytics_tests',
@@ -162,6 +163,7 @@ function analyticsTests({
   threshold_ms: thresholdMs,
   maturity_days: maturityDays,
   run,
+  slim,
 } = {}) {
   return this.apiClient.list(`analytics/tests/${this.pickRequiredArg({ kind }, 'kind')}`, {
     q,
@@ -176,6 +178,7 @@ function analyticsTests({
     threshold_ms: thresholdMs,
     maturity_days: maturityDays,
     run,
+    slim,
   });
 }
 

--- a/packages/enterprise/src/load-core.js
+++ b/packages/enterprise/src/load-core.js
@@ -27,5 +27,6 @@ export const {
   TOOL_DEFINITIONS,
   createApplication,
   slimList,
+  backendSlimQuery,
   withListOptions,
 } = coreModule;

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ import { ConfigurationError } from './core/errors.js';
 import { createLogger } from './core/logger.js';
 import { TestomatioMCPServer } from './mcp/server.js';
 import { TOOL_DEFINITIONS } from './mcp/tool-definitions.js';
-import { slimList, withListOptions } from './mcp/list-projection.js';
+import { backendSlimQuery, slimList, withListOptions } from './mcp/list-projection.js';
 import { selectTools } from './mcp/tool-profiles.js';
 import {
   ANALYTICS_STATS_TQL_INPUT_DESCRIPTION,
@@ -22,6 +22,7 @@ export {
   ConfigurationError,
   TOOL_DEFINITIONS,
   slimList,
+  backendSlimQuery,
   withListOptions,
   selectTools,
 };

--- a/src/mcp/list-projection.js
+++ b/src/mcp/list-projection.js
@@ -96,6 +96,14 @@ export function slimList(payload, { verbose = false, fields, entity } = {}) {
   return withViewMarker(applyToEnvelope(payload, (item) => stripHeavy(item, heavyFields)));
 }
 
+/**
+ * Ask the API to omit heavy list fields only when MCP does not need them for a
+ * full or custom projection.
+ */
+export function backendSlimQuery({ verbose = false, fields } = {}) {
+  return !verbose && !(Array.isArray(fields) && fields.length) ? { slim: true } : {};
+}
+
 const LIST_OPTION_PROPERTIES = {
   verbose: {
     type: 'boolean',

--- a/src/mcp/registry/attachments.js
+++ b/src/mcp/registry/attachments.js
@@ -4,9 +4,9 @@ import path from 'node:path';
 import { ATTACHMENT_RESOURCE_KEYS } from '../configs/attachments-config.js';
 
 export const attachmentMethods = {
-  listAttachmentsForKey({ resourceKey, resourceId }) {
+  listAttachmentsForKey({ resourceKey, resourceId, slim }) {
     this.assertSupportedAttachmentResourceKey(resourceKey);
-    return this.apiClient.list('attachments', { [resourceKey]: resourceId });
+    return this.apiClient.list('attachments', { [resourceKey]: resourceId, slim });
   },
 
   async uploadAttachmentForKey({ resourceKey, resourceId, filePath }) {

--- a/src/mcp/registry/handlers.js
+++ b/src/mcp/registry/handlers.js
@@ -1,7 +1,7 @@
 import { ENTITY_CRUD_CONFIGS } from '../configs/entity-crud-config.js';
 import { ATTACHMENT_SCOPED_TOOL_CONFIGS } from '../configs/attachments-config.js';
 import { ISSUE_SCOPED_TOOL_CONFIGS } from '../configs/issues-config.js';
-import { slimList } from '../list-projection.js';
+import { backendSlimQuery, slimList } from '../list-projection.js';
 
 export const handlerMethods = {
   registerEntityCrudHandlers(handlers) {
@@ -10,6 +10,7 @@ export const handlerMethods = {
 
       handlers[`${toolPrefix}_list`] = async (args = {}) => {
         const { verbose, fields, ...listArgs } = args;
+        Object.assign(listArgs, backendSlimQuery({ verbose, fields }));
         return this.asText(
           slimList(await this[listMethod](listArgs), {
             verbose,
@@ -43,6 +44,7 @@ export const handlerMethods = {
               page: args.page,
               per_page: args.per_page,
               source: args.source,
+              ...backendSlimQuery(args),
             }),
             { verbose: args.verbose, fields: args.fields, entity: 'issues' }
           )
@@ -71,6 +73,7 @@ export const handlerMethods = {
             await this.listAttachmentsForKey({
               resourceKey,
               resourceId: this.pickRequiredArg(args, resourceKey),
+              ...backendSlimQuery(args),
             }),
             { verbose: args.verbose, fields: args.fields, entity: 'attachments' }
           )
@@ -100,11 +103,14 @@ export const handlerMethods = {
     handlers.project_info = async () => this.asText(await this.apiClient.get('info'));
 
     handlers.tags_list = async (args = {}) =>
-      this.asText(slimList(await this.listTags(), { ...args, entity: 'tags' }));
+      this.asText(
+        slimList(await this.listTags(backendSlimQuery(args)), { ...args, entity: 'tags' })
+      );
     handlers.tags_get = async ({ tag_id: tagId }) => this.asText(await this.getTagByTitle(tagId));
 
     handlers.milestones_list = async (args = {}) => {
       const { verbose, fields, ...listArgs } = args;
+      Object.assign(listArgs, backendSlimQuery({ verbose, fields }));
       return this.asText(
         slimList(await this.listMilestones(listArgs), { verbose, fields, entity: 'milestones' })
       );
@@ -114,6 +120,7 @@ export const handlerMethods = {
 
     handlers.issues_list = async (args = {}) => {
       const { verbose, fields, ...listArgs } = args;
+      Object.assign(listArgs, backendSlimQuery({ verbose, fields }));
       return this.asText(
         slimList(await this.listIssues(listArgs), { verbose, fields, entity: 'issues' })
       );

--- a/src/mcp/registry/issues.js
+++ b/src/mcp/registry/issues.js
@@ -1,13 +1,14 @@
 import { ISSUE_RESOURCE_KEYS } from '../configs/issues-config.js';
 
 export const issueMethods = {
-  listIssues({ page, per_page: perPage, source, ...resourceQuery } = {}) {
+  listIssues({ page, per_page: perPage, source, slim, ...resourceQuery } = {}) {
     this.validateIssueResourceQuery(resourceQuery, { allowEmpty: true, allowMany: false });
     return this.listIssuesForResource({
       ...resourceQuery,
       page,
       per_page: perPage,
       source,
+      slim,
     });
   },
 
@@ -20,22 +21,24 @@ export const issueMethods = {
     });
   },
 
-  listIssuesForResource({ page, per_page: perPage, source, ...resourceQuery } = {}) {
+  listIssuesForResource({ page, per_page: perPage, source, slim, ...resourceQuery } = {}) {
     return this.apiClient.list('issues', {
       ...resourceQuery,
       page,
       per_page: perPage,
       source,
+      slim,
     });
   },
 
-  listIssuesForKey({ resourceKey, resourceId, page, per_page: perPage, source }) {
+  listIssuesForKey({ resourceKey, resourceId, page, per_page: perPage, source, slim }) {
     this.assertSupportedIssueResourceKey(resourceKey);
     return this.listIssuesForResource({
       [resourceKey]: resourceId,
       page,
       per_page: perPage,
       source,
+      slim,
     });
   },
 

--- a/src/mcp/registry/listings.js
+++ b/src/mcp/registry/listings.js
@@ -3,15 +3,17 @@ export const listingMethods = {
     page,
     per_page: perPage,
     tql,
+    slim,
   } = {}) {
     return this.apiClient.list('tests', {
       page,
       per_page: perPage,
       tql,
+      slim,
     });
   },
 
-  listSuites({ page, per_page: perPage, file_type: fileType, tag, labels, search_text: searchText } = {}) {
+  listSuites({ page, per_page: perPage, file_type: fileType, tag, labels, search_text: searchText, slim } = {}) {
     return this.apiClient.list('suites', {
       page,
       per_page: perPage,
@@ -19,6 +21,7 @@ export const listingMethods = {
       tag,
       labels,
       search_text: searchText,
+      slim,
     });
   },
 
@@ -26,11 +29,13 @@ export const listingMethods = {
     page,
     per_page: perPage,
     tql,
+    slim,
   } = {}) {
     return this.apiClient.list('runs', {
       page,
       per_page: perPage,
       tql,
+      slim,
     });
   },
 
@@ -53,6 +58,7 @@ export const listingMethods = {
     envs,
     rungroups,
     defects,
+    slim,
   } = {}) {
     return this.apiClient.list('testruns', {
       page,
@@ -73,26 +79,27 @@ export const listingMethods = {
       envs: Array.isArray(envs) ? envs.join(',') : envs,
       rungroups: Array.isArray(rungroups) ? rungroups.join(',') : rungroups,
       defects,
+      slim,
     });
   },
 
-  listRungroups({ page, per_page: perPage } = {}) {
-    return this.apiClient.list('rungroups', { page, per_page: perPage });
+  listRungroups({ page, per_page: perPage, slim } = {}) {
+    return this.apiClient.list('rungroups', { page, per_page: perPage, slim });
   },
 
-  listSteps({ page, per_page: perPage } = {}) {
-    return this.apiClient.list('steps', { page, per_page: perPage });
+  listSteps({ page, per_page: perPage, slim } = {}) {
+    return this.apiClient.list('steps', { page, per_page: perPage, slim });
   },
 
-  listSnippets({ page, per_page: perPage } = {}) {
-    return this.apiClient.list('snippets', { page, per_page: perPage });
+  listSnippets({ page, per_page: perPage, slim } = {}) {
+    return this.apiClient.list('snippets', { page, per_page: perPage, slim });
   },
 
-  listLabels({ page, per_page: perPage } = {}) {
-    return this.apiClient.list('labels', { page, per_page: perPage });
+  listLabels({ page, per_page: perPage, slim } = {}) {
+    return this.apiClient.list('labels', { page, per_page: perPage, slim });
   },
 
-  listPlans({ page, per_page: perPage, kind, hidden, labels, search_text: searchText } = {}) {
+  listPlans({ page, per_page: perPage, kind, hidden, labels, search_text: searchText, slim } = {}) {
     return this.apiClient.list('plans', {
       page,
       per_page: perPage,
@@ -100,19 +107,20 @@ export const listingMethods = {
       hidden,
       'labels[]': labels,
       search_text: searchText,
+      slim,
     });
   },
 
-  listRequirements({ page, per_page: perPage, source, scope } = {}) {
-    return this.apiClient.list('requirements', { page, per_page: perPage, source, scope });
+  listRequirements({ page, per_page: perPage, source, scope, slim } = {}) {
+    return this.apiClient.list('requirements', { page, per_page: perPage, source, scope, slim });
   },
 
-  listMilestones({ page, per_page: perPage, type, status } = {}) {
-    return this.apiClient.list('milestones', { page, per_page: perPage, type, status });
+  listMilestones({ page, per_page: perPage, type, status, slim } = {}) {
+    return this.apiClient.list('milestones', { page, per_page: perPage, type, status, slim });
   },
 
-  listTags() {
-    return this.apiClient.list('tags');
+  listTags({ slim } = {}) {
+    return this.apiClient.list('tags', { slim });
   },
 
   getTagByTitle(tagId) {


### PR DESCRIPTION
## Summary
  Passes `slim=true` to list API requests by default to reduce response payloads.

  - `verbose: true` disables both backend and MCP response trimming
  - `fields: [...]` requests the full API response before applying field projection
  - unsupported endpoints safely ignore the query parameter