### PR TITLE
Feat/list count aggregation

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1498,7 +1498,7 @@ The backend `slim` parameter is managed internally by MCP; callers should use `v
 
 ### Counts & Aggregation
 
-List operations accept `count` (and `group_by` where supported) to fetch totals and aggregated breakdowns without transferring the entity list — useful for "how many" questions instead of pulling full pages.
+List operations accept `count` (and `group_by`) to fetch totals and aggregated breakdowns without transferring the entity list — useful for "how many" questions instead of pulling full pages. Available on every list tool except the scoped `*_issues_list` / `*_attachments_list`.
 
 - `count: true` returns only `meta` with `total` (no `data`). Example response:
   ```json
@@ -1509,16 +1509,7 @@ List operations accept `count` (and `group_by` where supported) to fetch totals 
   { "meta": { "total": 59, "page": 1, "per_page": 30, "group_by": { "passed": 30, "failed": 8 } } }
   ```
 
-`group_by` is supported only by these list tools, with these field values:
-
-| Tool | `group_by` values |
-|------|-------------------|
-| `tests_list` | `state`, `priority`, `created_by` |
-| `testruns_list` | `status` |
-| `runs_list` | `status`, `created_by` |
-| `requirements_list` | `status`, `created_by` |
-
-When grouping by `created_by`, the breakdown is keyed by **user email** (e.g. `{"alice@example.com": 12}`), not by user ID.
+`group_by` is a free-form field name (e.g. `status`, `state`, `priority`, `created_by`); the backend validates which fields each resource supports. When grouping by `created_by`, the breakdown is keyed by **user email** (e.g. `{"alice@example.com": 12}`), not by user ID.
 
 When `count: true` is set, MCP omits `slim` — the response is meta-only, so field projection does not apply.
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1496,6 +1496,32 @@ List operations request slim responses from the API by default. Heavy entity fie
 
 The backend `slim` parameter is managed internally by MCP; callers should use `verbose` or `fields` rather than pass `slim` directly.
 
+### Counts & Aggregation
+
+List operations accept `count` (and `group_by` where supported) to fetch totals and aggregated breakdowns without transferring the entity list — useful for "how many" questions instead of pulling full pages.
+
+- `count: true` returns only `meta` with `total` (no `data`). Example response:
+  ```json
+  { "meta": { "total": 59, "page": 1, "per_page": 30 } }
+  ```
+- `group_by: <field>` (used with `count: true`) adds a `meta.group_by` breakdown. Example:
+  ```json
+  { "meta": { "total": 59, "page": 1, "per_page": 30, "group_by": { "passed": 30, "failed": 8 } } }
+  ```
+
+`group_by` is supported only by these list tools, with these field values:
+
+| Tool | `group_by` values |
+|------|-------------------|
+| `tests_list` | `state`, `priority`, `created_by` |
+| `testruns_list` | `status` |
+| `runs_list` | `status`, `created_by` |
+| `requirements_list` | `status`, `created_by` |
+
+When grouping by `created_by`, the breakdown is keyed by **user email** (e.g. `{"alice@example.com": 12}`), not by user ID.
+
+When `count: true` is set, MCP omits `slim` — the response is meta-only, so field projection does not apply.
+
 ### Issue Linking
 
 Two ways to link issues:

--- a/src/mcp/list-projection.js
+++ b/src/mcp/list-projection.js
@@ -151,14 +151,6 @@ export function withListOptions(tools, { extraNames = [] } = {}) {
   });
 }
 
-// Backend-supported `group_by` fields per primary entity (count=true&group_by=...).
-const GROUPABLE_FIELDS = {
-  tests: ['state', 'priority', 'created_by'],
-  testruns: ['status'],
-  runs: ['status', 'created_by'],
-  requirements: ['status', 'created_by'],
-};
-
 // Scoped list tools (*_issues_list, *_attachments_list) are filtered to one entity,
 // so count/group_by aggregation does not apply there.
 const SCOPED_LIST_INFIXES = ['_issues_', '_attachments_'];
@@ -174,12 +166,19 @@ function isPrimaryListToolName(name) {
 const COUNT_PROPERTY = {
   type: 'boolean',
   description:
-    'Return only metadata with total counts instead of the entity list. Pair with group_by (where supported) for an aggregated breakdown.',
+    'Return only metadata with total counts instead of the entity list. Pair with group_by for an aggregated breakdown.',
+};
+
+const GROUP_BY_PROPERTY = {
+  type: 'string',
+  description:
+    'Aggregate counts by this field, e.g. status, state, priority, created_by (use with count=true). The backend validates supported fields per resource. For created_by, counts are keyed by user email, not ID.',
 };
 
 /**
- * Inject `count` into every primary list tool and `group_by` (enum) into the entities
- * the backend can aggregate. Scoped list tools are left untouched.
+ * Inject `count` and `group_by` into every primary list tool. `group_by` is a
+ * free-form string — the backend is the source of truth for which fields each
+ * resource accepts. Scoped list tools (*_issues_list, *_attachments_list) are skipped.
  *
  * @param {Array} tools
  */
@@ -187,19 +186,11 @@ export function withCountGroupOptions(tools) {
   return tools.map((tool) => {
     if (!tool || !isPrimaryListToolName(tool.name)) return tool;
     const inputSchema = tool.inputSchema || { type: 'object', properties: {} };
-    const properties = { ...(inputSchema.properties || {}), count: COUNT_PROPERTY };
-    const entity = tool.name.replace(/_list$/, '');
-    const groupable = GROUPABLE_FIELDS[entity];
-    if (Array.isArray(groupable) && groupable.length) {
-      const createdByNote = groupable.includes('created_by')
-        ? ' When grouping by created_by, counts are keyed by user email, not ID.'
-        : '';
-      properties.group_by = {
-        type: 'string',
-        enum: groupable,
-        description: `Aggregate counts by this field (use with count=true). One of: ${groupable.join(', ')}.${createdByNote}`,
-      };
-    }
+    const properties = {
+      ...(inputSchema.properties || {}),
+      count: COUNT_PROPERTY,
+      group_by: GROUP_BY_PROPERTY,
+    };
     return { ...tool, inputSchema: { ...inputSchema, properties } };
   });
 }

--- a/src/mcp/list-projection.js
+++ b/src/mcp/list-projection.js
@@ -98,9 +98,13 @@ export function slimList(payload, { verbose = false, fields, entity } = {}) {
 
 /**
  * Ask the API to omit heavy list fields only when MCP does not need them for a
- * full or custom projection.
+ * full or custom projection. When `count` is requested the response is meta only,
+ * so `slim` is irrelevant and must not be sent alongside `count`.
  */
-export function backendSlimQuery({ verbose = false, fields } = {}) {
+export function backendSlimQuery({ verbose = false, fields, count = false } = {}) {
+  if (count) {
+    return {};
+  }
   return !verbose && !(Array.isArray(fields) && fields.length) ? { slim: true } : {};
 }
 
@@ -144,5 +148,58 @@ export function withListOptions(tools, { extraNames = [] } = {}) {
         properties,
       },
     };
+  });
+}
+
+// Backend-supported `group_by` fields per primary entity (count=true&group_by=...).
+const GROUPABLE_FIELDS = {
+  tests: ['state', 'priority', 'created_by'],
+  testruns: ['status'],
+  runs: ['status', 'created_by'],
+  requirements: ['status', 'created_by'],
+};
+
+// Scoped list tools (*_issues_list, *_attachments_list) are filtered to one entity,
+// so count/group_by aggregation does not apply there.
+const SCOPED_LIST_INFIXES = ['_issues_', '_attachments_'];
+
+function isPrimaryListToolName(name) {
+  return (
+    typeof name === 'string' &&
+    name.endsWith('_list') &&
+    !SCOPED_LIST_INFIXES.some((infix) => name.includes(infix))
+  );
+}
+
+const COUNT_PROPERTY = {
+  type: 'boolean',
+  description:
+    'Return only metadata with total counts instead of the entity list. Pair with group_by (where supported) for an aggregated breakdown.',
+};
+
+/**
+ * Inject `count` into every primary list tool and `group_by` (enum) into the entities
+ * the backend can aggregate. Scoped list tools are left untouched.
+ *
+ * @param {Array} tools
+ */
+export function withCountGroupOptions(tools) {
+  return tools.map((tool) => {
+    if (!tool || !isPrimaryListToolName(tool.name)) return tool;
+    const inputSchema = tool.inputSchema || { type: 'object', properties: {} };
+    const properties = { ...(inputSchema.properties || {}), count: COUNT_PROPERTY };
+    const entity = tool.name.replace(/_list$/, '');
+    const groupable = GROUPABLE_FIELDS[entity];
+    if (Array.isArray(groupable) && groupable.length) {
+      const createdByNote = groupable.includes('created_by')
+        ? ' When grouping by created_by, counts are keyed by user email, not ID.'
+        : '';
+      properties.group_by = {
+        type: 'string',
+        enum: groupable,
+        description: `Aggregate counts by this field (use with count=true). One of: ${groupable.join(', ')}.${createdByNote}`,
+      };
+    }
+    return { ...tool, inputSchema: { ...inputSchema, properties } };
   });
 }

--- a/src/mcp/registry/handlers.js
+++ b/src/mcp/registry/handlers.js
@@ -10,7 +10,7 @@ export const handlerMethods = {
 
       handlers[`${toolPrefix}_list`] = async (args = {}) => {
         const { verbose, fields, ...listArgs } = args;
-        Object.assign(listArgs, backendSlimQuery({ verbose, fields }));
+        Object.assign(listArgs, backendSlimQuery({ verbose, fields, count: listArgs.count }));
         return this.asText(
           slimList(await this[listMethod](listArgs), {
             verbose,
@@ -102,15 +102,16 @@ export const handlerMethods = {
   registerGlobalHandlers(handlers) {
     handlers.project_info = async () => this.asText(await this.apiClient.get('info'));
 
-    handlers.tags_list = async (args = {}) =>
-      this.asText(
-        slimList(await this.listTags(backendSlimQuery(args)), { ...args, entity: 'tags' })
-      );
+    handlers.tags_list = async (args = {}) => {
+      const { verbose, fields, ...listArgs } = args;
+      Object.assign(listArgs, backendSlimQuery({ verbose, fields, count: listArgs.count }));
+      return this.asText(slimList(await this.listTags(listArgs), { ...args, entity: 'tags' }));
+    };
     handlers.tags_get = async ({ tag_id: tagId }) => this.asText(await this.getTagByTitle(tagId));
 
     handlers.milestones_list = async (args = {}) => {
       const { verbose, fields, ...listArgs } = args;
-      Object.assign(listArgs, backendSlimQuery({ verbose, fields }));
+      Object.assign(listArgs, backendSlimQuery({ verbose, fields, count: listArgs.count }));
       return this.asText(
         slimList(await this.listMilestones(listArgs), { verbose, fields, entity: 'milestones' })
       );
@@ -120,7 +121,7 @@ export const handlerMethods = {
 
     handlers.issues_list = async (args = {}) => {
       const { verbose, fields, ...listArgs } = args;
-      Object.assign(listArgs, backendSlimQuery({ verbose, fields }));
+      Object.assign(listArgs, backendSlimQuery({ verbose, fields, count: listArgs.count }));
       return this.asText(
         slimList(await this.listIssues(listArgs), { verbose, fields, entity: 'issues' })
       );

--- a/src/mcp/registry/listings.js
+++ b/src/mcp/registry/listings.js
@@ -3,17 +3,21 @@ export const listingMethods = {
     page,
     per_page: perPage,
     tql,
+    count,
+    group_by: groupBy,
     slim,
   } = {}) {
     return this.apiClient.list('tests', {
       page,
       per_page: perPage,
       tql,
+      count,
+      group_by: groupBy,
       slim,
     });
   },
 
-  listSuites({ page, per_page: perPage, file_type: fileType, tag, labels, search_text: searchText, slim } = {}) {
+  listSuites({ page, per_page: perPage, file_type: fileType, tag, labels, search_text: searchText, count, slim } = {}) {
     return this.apiClient.list('suites', {
       page,
       per_page: perPage,
@@ -21,6 +25,7 @@ export const listingMethods = {
       tag,
       labels,
       search_text: searchText,
+      count,
       slim,
     });
   },
@@ -29,12 +34,16 @@ export const listingMethods = {
     page,
     per_page: perPage,
     tql,
+    count,
+    group_by: groupBy,
     slim,
   } = {}) {
     return this.apiClient.list('runs', {
       page,
       per_page: perPage,
       tql,
+      count,
+      group_by: groupBy,
       slim,
     });
   },
@@ -58,6 +67,8 @@ export const listingMethods = {
     envs,
     rungroups,
     defects,
+    count,
+    group_by: groupBy,
     slim,
   } = {}) {
     return this.apiClient.list('testruns', {
@@ -79,27 +90,29 @@ export const listingMethods = {
       envs: Array.isArray(envs) ? envs.join(',') : envs,
       rungroups: Array.isArray(rungroups) ? rungroups.join(',') : rungroups,
       defects,
+      count,
+      group_by: groupBy,
       slim,
     });
   },
 
-  listRungroups({ page, per_page: perPage, slim } = {}) {
-    return this.apiClient.list('rungroups', { page, per_page: perPage, slim });
+  listRungroups({ page, per_page: perPage, count, slim } = {}) {
+    return this.apiClient.list('rungroups', { page, per_page: perPage, count, slim });
   },
 
-  listSteps({ page, per_page: perPage, slim } = {}) {
-    return this.apiClient.list('steps', { page, per_page: perPage, slim });
+  listSteps({ page, per_page: perPage, count, slim } = {}) {
+    return this.apiClient.list('steps', { page, per_page: perPage, count, slim });
   },
 
-  listSnippets({ page, per_page: perPage, slim } = {}) {
-    return this.apiClient.list('snippets', { page, per_page: perPage, slim });
+  listSnippets({ page, per_page: perPage, count, slim } = {}) {
+    return this.apiClient.list('snippets', { page, per_page: perPage, count, slim });
   },
 
-  listLabels({ page, per_page: perPage, slim } = {}) {
-    return this.apiClient.list('labels', { page, per_page: perPage, slim });
+  listLabels({ page, per_page: perPage, count, slim } = {}) {
+    return this.apiClient.list('labels', { page, per_page: perPage, count, slim });
   },
 
-  listPlans({ page, per_page: perPage, kind, hidden, labels, search_text: searchText, slim } = {}) {
+  listPlans({ page, per_page: perPage, kind, hidden, labels, search_text: searchText, count, slim } = {}) {
     return this.apiClient.list('plans', {
       page,
       per_page: perPage,
@@ -107,20 +120,21 @@ export const listingMethods = {
       hidden,
       'labels[]': labels,
       search_text: searchText,
+      count,
       slim,
     });
   },
 
-  listRequirements({ page, per_page: perPage, source, scope, slim } = {}) {
-    return this.apiClient.list('requirements', { page, per_page: perPage, source, scope, slim });
+  listRequirements({ page, per_page: perPage, source, scope, count, group_by: groupBy, slim } = {}) {
+    return this.apiClient.list('requirements', { page, per_page: perPage, source, scope, count, group_by: groupBy, slim });
   },
 
-  listMilestones({ page, per_page: perPage, type, status, slim } = {}) {
-    return this.apiClient.list('milestones', { page, per_page: perPage, type, status, slim });
+  listMilestones({ page, per_page: perPage, type, status, count, slim } = {}) {
+    return this.apiClient.list('milestones', { page, per_page: perPage, type, status, count, slim });
   },
 
-  listTags({ slim } = {}) {
-    return this.apiClient.list('tags', { slim });
+  listTags({ count, slim } = {}) {
+    return this.apiClient.list('tags', { count, slim });
   },
 
   getTagByTitle(tagId) {

--- a/src/mcp/registry/listings.js
+++ b/src/mcp/registry/listings.js
@@ -17,7 +17,7 @@ export const listingMethods = {
     });
   },
 
-  listSuites({ page, per_page: perPage, file_type: fileType, tag, labels, search_text: searchText, count, slim } = {}) {
+  listSuites({ page, per_page: perPage, file_type: fileType, tag, labels, search_text: searchText, count, group_by: groupBy, slim } = {}) {
     return this.apiClient.list('suites', {
       page,
       per_page: perPage,
@@ -26,6 +26,7 @@ export const listingMethods = {
       labels,
       search_text: searchText,
       count,
+      group_by: groupBy,
       slim,
     });
   },
@@ -96,23 +97,23 @@ export const listingMethods = {
     });
   },
 
-  listRungroups({ page, per_page: perPage, count, slim } = {}) {
-    return this.apiClient.list('rungroups', { page, per_page: perPage, count, slim });
+  listRungroups({ page, per_page: perPage, count, group_by: groupBy, slim } = {}) {
+    return this.apiClient.list('rungroups', { page, per_page: perPage, count, group_by: groupBy, slim });
   },
 
-  listSteps({ page, per_page: perPage, count, slim } = {}) {
-    return this.apiClient.list('steps', { page, per_page: perPage, count, slim });
+  listSteps({ page, per_page: perPage, count, group_by: groupBy, slim } = {}) {
+    return this.apiClient.list('steps', { page, per_page: perPage, count, group_by: groupBy, slim });
   },
 
-  listSnippets({ page, per_page: perPage, count, slim } = {}) {
-    return this.apiClient.list('snippets', { page, per_page: perPage, count, slim });
+  listSnippets({ page, per_page: perPage, count, group_by: groupBy, slim } = {}) {
+    return this.apiClient.list('snippets', { page, per_page: perPage, count, group_by: groupBy, slim });
   },
 
-  listLabels({ page, per_page: perPage, count, slim } = {}) {
-    return this.apiClient.list('labels', { page, per_page: perPage, count, slim });
+  listLabels({ page, per_page: perPage, count, group_by: groupBy, slim } = {}) {
+    return this.apiClient.list('labels', { page, per_page: perPage, count, group_by: groupBy, slim });
   },
 
-  listPlans({ page, per_page: perPage, kind, hidden, labels, search_text: searchText, count, slim } = {}) {
+  listPlans({ page, per_page: perPage, kind, hidden, labels, search_text: searchText, count, group_by: groupBy, slim } = {}) {
     return this.apiClient.list('plans', {
       page,
       per_page: perPage,
@@ -121,6 +122,7 @@ export const listingMethods = {
       'labels[]': labels,
       search_text: searchText,
       count,
+      group_by: groupBy,
       slim,
     });
   },
@@ -129,12 +131,12 @@ export const listingMethods = {
     return this.apiClient.list('requirements', { page, per_page: perPage, source, scope, count, group_by: groupBy, slim });
   },
 
-  listMilestones({ page, per_page: perPage, type, status, count, slim } = {}) {
-    return this.apiClient.list('milestones', { page, per_page: perPage, type, status, count, slim });
+  listMilestones({ page, per_page: perPage, type, status, count, group_by: groupBy, slim } = {}) {
+    return this.apiClient.list('milestones', { page, per_page: perPage, type, status, count, group_by: groupBy, slim });
   },
 
-  listTags({ count, slim } = {}) {
-    return this.apiClient.list('tags', { count, slim });
+  listTags({ count, group_by: groupBy, slim } = {}) {
+    return this.apiClient.list('tags', { count, group_by: groupBy, slim });
   },
 
   getTagByTitle(tagId) {

--- a/src/mcp/tool-definitions.js
+++ b/src/mcp/tool-definitions.js
@@ -14,9 +14,9 @@ import { ISSUES_TOOLS } from './definitions/issues.js';
 import { PLANS_TOOLS } from './definitions/plans.js';
 import { REQUIREMENTS_TOOLS } from './definitions/requirements.js';
 import { ATTACHMENT_TOOLS } from './definitions/attachments.js';
-import { withListOptions } from './list-projection.js';
+import { withListOptions, withCountGroupOptions } from './list-projection.js';
 
-export const TOOL_DEFINITIONS = withListOptions([
+export const TOOL_DEFINITIONS = withCountGroupOptions(withListOptions([
   ...SYSTEM_TOOLS,
   ...PROJECT_TOOLS,
   ...TESTS_TOOLS,
@@ -33,4 +33,4 @@ export const TOOL_DEFINITIONS = withListOptions([
   ...ATTACHMENT_TOOLS,
   ...PLANS_TOOLS,
   ...REQUIREMENTS_TOOLS,
-]);
+]));


### PR DESCRIPTION
## Summary

Agents can now get totals and aggregated breakdowns - e.g. "how many tests per status/priority" - in a single lightweight call, instead of pulling full lists and counting client-side. This wires the backend's `count=true` and `count=true&group_by=<field>` through the MCP layer and documents them; `group_by` is a free-form string validated by the backend, so MCP holds no hardcoded field list