### PR TITLE
Add branches support with branch-scoped tests, suites and runs

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -21,6 +21,7 @@ Complete reference for the MCP tools available in the Testomat.io MCP Server.
 - [Issue Management](#issue-management-global)
 - [Attachment Management](#attachment-management)
 - [Requirement Management](#requirement-management)
+- [Branch Management](#branch-management)
 - [Enterprise Analytics](#enterprise-analytics)
 
 ---
@@ -110,6 +111,7 @@ For the full syntax and field reference, see the official docs: https://docs.tes
 | page | integer | No | Page number (min: 1) |
 | per_page | integer | No | Items per page (min: 1, max: 100) |
 | tql | string | No | TQL filter for tests. Examples: `priority == 'high'`, `state == 'automated'`, `suite % 'Checkout'` |
+| branch | string | No | Branch slug to scope the operation to (omit or `main` for the main branch). See [Branch Scoping](#branch-scoping) |
 
 **Example:**
 ```json
@@ -135,6 +137,7 @@ Get a specific test by ID.
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
 | test_id | string | Yes | Test ID |
+| branch | string | No | Branch slug to scope the operation to (omit or `main` for the main branch). See [Branch Scoping](#branch-scoping) |
 
 **Example:**
 ```json
@@ -166,6 +169,7 @@ Create a new test.
 | code | string | No | Test code/automation reference |
 | state | string | No | One of: `manual`, `detached`, `automated` |
 | link | array | No | Links to labels, tags, milestones, issues, or jira |
+| branch | string | No | Branch slug to scope the operation to (omit or `main` for the main branch). See [Branch Scoping](#branch-scoping) |
 
 **Link Array Format:**
 ```json
@@ -218,6 +222,7 @@ Update an existing test.
 | state | string | No | One of: `manual`, `detached`, `automated` |
 | sync | boolean | No | Sync with automation |
 | link | array | No | Link updates |
+| branch | string | No | Branch slug to scope the operation to (omit or `main` for the main branch). See [Branch Scoping](#branch-scoping) |
 
 **Example:**
 ```json
@@ -243,6 +248,7 @@ Delete a test.
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
 | test_id | string | Yes | Test ID |
+| branch | string | No | Branch slug to scope the operation to (omit or `main` for the main branch). See [Branch Scoping](#branch-scoping) |
 
 **Example:**
 ```json
@@ -363,6 +369,7 @@ List suites as a tree structure.
 | tag | string | No | Filter by tag |
 | labels | string | No | Filter by labels |
 | search_text | string | No | Search text |
+| branch | string | No | Branch slug to scope the operation to (omit or `main` for the main branch). See [Branch Scoping](#branch-scoping) |
 
 **API Endpoint:** `GET /api/v2/{project_id}/suites`
 
@@ -376,6 +383,7 @@ Get a specific suite by ID.
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
 | suite_id | string | Yes | Suite ID |
+| branch | string | No | Branch slug to scope the operation to (omit or `main` for the main branch). See [Branch Scoping](#branch-scoping) |
 
 **API Endpoint:** `GET /api/v2/{project_id}/suites/{id}`
 
@@ -397,6 +405,7 @@ Create a new suite.
 | file | string | No | File reference |
 | children | array | No | Child suites |
 | link | array | No | Links to labels, tags, milestones, issues, jira, or requirements |
+| branch | string | No | Branch slug to scope the operation to (omit or `main` for the main branch). See [Branch Scoping](#branch-scoping) |
 
 **API Endpoint:** `POST /api/v2/{project_id}/suites`
 
@@ -419,6 +428,7 @@ Update an existing suite.
 | file | string | No | File reference |
 | children | array | No | Child suites |
 | link | array | No | Link updates for labels, tags, milestones, issues, jira, or requirements |
+| branch | string | No | Branch slug to scope the operation to (omit or `main` for the main branch). See [Branch Scoping](#branch-scoping) |
 
 **API Endpoint:** `PUT /api/v2/{project_id}/suites/{id}`
 
@@ -432,6 +442,7 @@ Delete a suite.
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
 | suite_id | string | Yes | Suite ID |
+| branch | string | No | Branch slug to scope the operation to (omit or `main` for the main branch). See [Branch Scoping](#branch-scoping) |
 
 **API Endpoint:** `DELETE /api/v2/{project_id}/suites/{id}`
 
@@ -462,6 +473,7 @@ For the full syntax and field reference, see the official docs: https://docs.tes
 | page | integer | No | Page number |
 | per_page | integer | No | Items per page |
 | tql | string | No | TQL filter for runs. Examples: `title % 'Manual tests'`, `plan == '{PLAN_ID}'`, `finished and with_defect` |
+| branch | string | No | Branch slug to scope the operation to (omit or `main` for the main branch). See [Branch Scoping](#branch-scoping) |
 
 **Example:**
 ```json
@@ -487,6 +499,7 @@ Get a specific run by ID.
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
 | run_id | string | Yes | Run ID |
+| branch | string | No | Branch slug to scope the operation to (omit or `main` for the main branch). See [Branch Scoping](#branch-scoping) |
 
 **API Endpoint:** `GET /api/v2/{project_id}/runs/{id}`
 
@@ -511,6 +524,7 @@ Create a new test run.
 | suite_ids | array | No | Array of suite public UIDs whose tests to include |
 | envs | array | No | Array of environment names |
 | link | array | No | Links to labels, tags, milestones, issues, or jira |
+| branch | string | No | Branch slug to scope the operation to (omit or `main` for the main branch). See [Branch Scoping](#branch-scoping) |
 
 **Example:**
 ```json
@@ -560,6 +574,7 @@ Update an existing run.
 | test_ids | array | No | Test public UIDs |
 | suite_ids | array | No | Suite public UIDs whose tests to include |
 | link | array | No | Link updates for labels, tags, milestones, issues, or jira |
+| branch | string | No | Branch slug to scope the operation to (omit or `main` for the main branch). See [Branch Scoping](#branch-scoping) |
 
 **Status Event Example:**
 ```json
@@ -584,6 +599,7 @@ Delete a run.
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
 | run_id | string | Yes | Run ID |
+| branch | string | No | Branch slug to scope the operation to (omit or `main` for the main branch). See [Branch Scoping](#branch-scoping) |
 
 **API Endpoint:** `DELETE /api/v2/{project_id}/runs/{id}`
 
@@ -1456,7 +1472,102 @@ Delete a requirement.
 
 ---
 
+## Branch Management
+
+Requires the `branches` subscription feature (enterprise plan). Branches are identified by slug.
+
+### branches_list
+
+List project branches.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| page | integer | No | Page number (min: 1) |
+| per_page | integer | No | Items per page (min: 1, max: 100) |
+| filter_state | string | No | Filter by state: `active`, `merged` |
+| filter_title | string | No | Filter by title (partial substring match) |
+| count | boolean | No | Return only total counts |
+| group_by | string | No | Aggregate counts by field (use with count=true) |
+
+**API Endpoint:** `GET /api/v2/{project_id}/branches`
+
+---
+
+### branches_get
+
+Get a branch by slug.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| branch_id | string | Yes | Branch slug |
+
+**Returns:** Branch slug, title, state (`active`/`merged`), tests_count, suites_count.
+
+**API Endpoint:** `GET /api/v2/{project_id}/branches/{slug}`
+
+---
+
+### branches_create
+
+Create a branch.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| title | string | Yes | Branch title; a slug is generated from it |
+
+**API Endpoint:** `POST /api/v2/{project_id}/branches`
+
+---
+
+### branches_update
+
+Update a branch title.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| branch_id | string | Yes | Branch slug |
+| title | string | No | New branch title |
+
+**API Endpoint:** `PUT /api/v2/{project_id}/branches/{slug}`
+
+---
+
+### branches_delete
+
+Delete a branch.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| branch_id | string | Yes | Branch slug |
+
+**API Endpoint:** `DELETE /api/v2/{project_id}/branches/{slug}`
+
+---
+
 ## Common Patterns
+
+### Branch Scoping
+
+Tests, suites, and runs CRUD tools accept an optional `branch` parameter (branch slug).
+Omit it (or pass `main`) to operate on the main branch.
+
+- For **tests** and **suites**: a matching branch-local record is used when it exists, falling back to main; updating or deleting a main-only record creates an isolated branch-local copy rather than mutating main.
+- For **runs**: creating a run under a branch tags it with that branch (it is then only visible/reachable when the same `branch` is passed again), but updating or deleting an existing run always applies directly to whatever record was found — it is never forked.
+
+```json
+{
+  "name": "tests_list",
+  "arguments": {
+    "branch": "feature-login",
+    "tql": "priority == 'high'"
+  }
+}
+```
 
 ### API Sessions
 

--- a/src/api/testomatio-client.js
+++ b/src/api/testomatio-client.js
@@ -27,8 +27,8 @@ export class TestomatioApiClient {
     return this.http.request('GET', this.buildPath(resource, id), { query });
   }
 
-  async create(resource, body = {}) {
-    return this.mutate('POST', this.buildPath(resource), { body });
+  async create(resource, body = {}, query = {}) {
+    return this.mutate('POST', this.buildPath(resource), { query, body });
   }
 
   async createMultipart(resource, formData, query = {}) {
@@ -39,16 +39,16 @@ export class TestomatioApiClient {
     return this.mutate('POST', this.buildPath(resource), { query, body });
   }
 
-  async update(resource, id, body = {}) {
-    return this.mutate('PUT', this.buildPath(resource, id), { body });
+  async update(resource, id, body = {}, query = {}) {
+    return this.mutate('PUT', this.buildPath(resource, id), { query, body });
   }
 
-  async patch(resource, id, body = {}) {
-    return this.mutate('PATCH', this.buildPath(resource, id), { body });
+  async patch(resource, id, body = {}, query = {}) {
+    return this.mutate('PATCH', this.buildPath(resource, id), { query, body });
   }
 
-  async patchMultipart(resource, id, formData) {
-    return this.mutate('PATCH', this.buildPath(resource, id), { body: formData });
+  async patchMultipart(resource, id, formData, query = {}) {
+    return this.mutate('PATCH', this.buildPath(resource, id), { query, body: formData });
   }
 
   async delete(resource, id, query = {}) {

--- a/src/mcp/configs/entity-crud-config.js
+++ b/src/mcp/configs/entity-crud-config.js
@@ -8,6 +8,7 @@ export const ENTITY_CRUD_CONFIGS = [
     wrapperKey: 'test',
     createMode: 'wrapped',
     updateMode: 'wrapped',
+    queryArgs: ['branch'],
   },
   {
     toolPrefix: 'suites',
@@ -18,6 +19,7 @@ export const ENTITY_CRUD_CONFIGS = [
     wrapperKey: 'suite',
     createMode: 'wrapped',
     updateMode: 'wrapped',
+    queryArgs: ['branch'],
   },
   {
     toolPrefix: 'runs',
@@ -26,6 +28,7 @@ export const ENTITY_CRUD_CONFIGS = [
     listMethod: 'listRuns',
     createMode: 'run',
     updateMode: 'run',
+    queryArgs: ['branch'],
   },
   {
     toolPrefix: 'testruns',
@@ -97,5 +100,15 @@ export const ENTITY_CRUD_CONFIGS = [
     createMode: 'requirement',
     updateMode: 'requirement',
     updateMethod: 'patch',
+  },
+  {
+    toolPrefix: 'branches',
+    resource: 'branches',
+    idArg: 'branch_id',
+    listMethod: 'listBranches',
+    payloadBuilder: 'buildBranchPayload',
+    wrapperKey: 'branch',
+    createMode: 'wrapped',
+    updateMode: 'wrapped',
   },
 ];

--- a/src/mcp/definitions/branches.js
+++ b/src/mcp/definitions/branches.js
@@ -1,0 +1,110 @@
+export const BRANCH_PARAM = {
+  "type": "string",
+  "description": "Branch slug to scope the request to (omit or main for the main branch). For tests and suites, a branch-local record is used when it exists, falling back to main; updating/deleting a main-only record forks an isolated copy into the branch. Runs are tagged with the branch (only reachable with the same branch afterwards). Requires the branches feature."
+};
+
+export const BRANCHES_TOOLS = [
+  {
+    "name": "branches_list",
+    "description":
+      'List project branches (/api/v2/{project_id}/branches). Requires the branches feature (enterprise plan). Use filter[state] / filter[title] to narrow down.',
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "page": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "per_page": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 100
+        },
+        "filter_state": {
+          "type": "string",
+          "enum": [
+            "active",
+            "merged"
+          ],
+          "description": "Filter by branch state"
+        },
+        "filter_title": {
+          "type": "string",
+          "description": "Filter by title (partial substring match)"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "branches_get",
+    "description": "Get branch by slug",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "branch_id": {
+          "type": "string",
+          "description": "Branch slug"
+        }
+      },
+      "required": [
+        "branch_id"
+      ],
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "branches_create",
+    "description": "Create branch (/api/v2/{project_id}/branches)",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string",
+          "description": "Branch title; a slug is generated from it"
+        }
+      },
+      "required": [
+        "title"
+      ],
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "branches_update",
+    "description": "Update branch title (/api/v2/{project_id}/branches/{slug})",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "branch_id": {
+          "type": "string",
+          "description": "Branch slug"
+        },
+        "title": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "branch_id"
+      ],
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "branches_delete",
+    "description": "Delete branch by slug",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "branch_id": {
+          "type": "string",
+          "description": "Branch slug"
+        }
+      },
+      "required": [
+        "branch_id"
+      ],
+      "additionalProperties": false
+    }
+  }
+];

--- a/src/mcp/definitions/runs.js
+++ b/src/mcp/definitions/runs.js
@@ -1,4 +1,5 @@
 import { RUNS_TQL_INPUT_DESCRIPTION, RUNS_TQL_REFERENCE } from './tql-reference.js';
+import { BRANCH_PARAM } from './branches.js';
 
 export const RUNS_TOOLS = [
   {
@@ -19,7 +20,8 @@ export const RUNS_TOOLS = [
         "tql": {
           "type": "string",
           "description": RUNS_TQL_INPUT_DESCRIPTION
-        }
+        },
+        "branch": BRANCH_PARAM
       },
       "additionalProperties": false
     }
@@ -32,7 +34,8 @@ export const RUNS_TOOLS = [
       "properties": {
         "run_id": {
           "type": "string"
-        }
+        },
+        "branch": BRANCH_PARAM
       },
       "required": [
         "run_id"
@@ -135,7 +138,8 @@ export const RUNS_TOOLS = [
             ],
             "additionalProperties": false
           }
-        }
+        },
+        "branch": BRANCH_PARAM
       },
       "required": [
         "title"
@@ -240,7 +244,8 @@ export const RUNS_TOOLS = [
             ],
             "additionalProperties": false
           }
-        }
+        },
+        "branch": BRANCH_PARAM
       },
       "required": [
         "run_id"
@@ -256,7 +261,8 @@ export const RUNS_TOOLS = [
       "properties": {
         "run_id": {
           "type": "string"
-        }
+        },
+        "branch": BRANCH_PARAM
       },
       "required": [
         "run_id"

--- a/src/mcp/definitions/suites.js
+++ b/src/mcp/definitions/suites.js
@@ -1,3 +1,4 @@
+import { BRANCH_PARAM } from './branches.js';
 export const SUITES_TOOLS = [
   {
     "name": "suites_list",
@@ -29,7 +30,8 @@ export const SUITES_TOOLS = [
         },
         "search_text": {
           "type": "string"
-        }
+        },
+        "branch": BRANCH_PARAM
       },
       "additionalProperties": false
     }
@@ -42,7 +44,8 @@ export const SUITES_TOOLS = [
       "properties": {
         "suite_id": {
           "type": "string"
-        }
+        },
+        "branch": BRANCH_PARAM
       },
       "required": [
         "suite_id"
@@ -120,7 +123,8 @@ export const SUITES_TOOLS = [
             ],
             "additionalProperties": false
           }
-        }
+        },
+        "branch": BRANCH_PARAM
       },
       "required": [
         "title"
@@ -201,7 +205,8 @@ export const SUITES_TOOLS = [
             ],
             "additionalProperties": false
           }
-        }
+        },
+        "branch": BRANCH_PARAM
       },
       "required": [
         "suite_id"
@@ -217,7 +222,8 @@ export const SUITES_TOOLS = [
       "properties": {
         "suite_id": {
           "type": "string"
-        }
+        },
+        "branch": BRANCH_PARAM
       },
       "required": [
         "suite_id"

--- a/src/mcp/definitions/tests.js
+++ b/src/mcp/definitions/tests.js
@@ -1,4 +1,5 @@
 import { TESTS_TQL_INPUT_DESCRIPTION, TESTS_TQL_REFERENCE } from './tql-reference.js';
+import { BRANCH_PARAM } from './branches.js';
 
 export const TESTS_TOOLS = [
   {
@@ -19,7 +20,8 @@ export const TESTS_TOOLS = [
         "tql": {
           "type": "string",
           "description": TESTS_TQL_INPUT_DESCRIPTION
-        }
+        },
+        "branch": BRANCH_PARAM
       },
       "additionalProperties": false
     }
@@ -32,7 +34,8 @@ export const TESTS_TOOLS = [
       "properties": {
         "test_id": {
           "type": "string"
-        }
+        },
+        "branch": BRANCH_PARAM
       },
       "required": [
         "test_id"
@@ -116,7 +119,8 @@ export const TESTS_TOOLS = [
             ],
             "additionalProperties": false
           }
-        }
+        },
+        "branch": BRANCH_PARAM
       },
       "required": [
         "title",
@@ -207,7 +211,8 @@ export const TESTS_TOOLS = [
             ],
             "additionalProperties": false
           }
-        }
+        },
+        "branch": BRANCH_PARAM
       },
       "required": [
         "test_id"
@@ -223,7 +228,8 @@ export const TESTS_TOOLS = [
       "properties": {
         "test_id": {
           "type": "string"
-        }
+        },
+        "branch": BRANCH_PARAM
       },
       "required": [
         "test_id"

--- a/src/mcp/registry/handlers.js
+++ b/src/mcp/registry/handlers.js
@@ -19,17 +19,27 @@ export const handlerMethods = {
           })
         );
       };
-      handlers[`${toolPrefix}_get`] = async (args = {}) =>
-        this.asText(await this.apiClient.get(resource, this.pickRequiredArg(args, idArg)));
-      handlers[`${toolPrefix}_create`] = async (args = {}) =>
-        this.asText(await this.executeCreate(spec, args));
+      handlers[`${toolPrefix}_get`] = async (args = {}) => {
+        const id = this.pickRequiredArg(args, idArg);
+        return this.asText(
+          await this.apiClient.get(resource, id, this.pickQueryArgs(spec, args))
+        );
+      };
+      handlers[`${toolPrefix}_create`] = async (args = {}) => {
+        const { query, payloadArgs } = this.splitQueryArgs(spec, args);
+        return this.asText(await this.executeCreate(spec, payloadArgs, query));
+      };
       handlers[`${toolPrefix}_update`] = async (args = {}) => {
         const id = this.pickRequiredArg(args, idArg);
-        const payloadArgs = this.omitArg(args, idArg);
-        return this.asText(await this.executeUpdate(spec, id, payloadArgs));
+        const { query, payloadArgs } = this.splitQueryArgs(spec, this.omitArgs(args, [idArg]));
+        return this.asText(await this.executeUpdate(spec, id, payloadArgs, query));
       };
-      handlers[`${toolPrefix}_delete`] = async (args = {}) =>
-        this.asText(await this.apiClient.delete(resource, this.pickRequiredArg(args, idArg)));
+      handlers[`${toolPrefix}_delete`] = async (args = {}) => {
+        const id = this.pickRequiredArg(args, idArg);
+        return this.asText(
+          await this.apiClient.delete(resource, id, this.pickQueryArgs(spec, args))
+        );
+      };
     }
   },
 
@@ -139,34 +149,58 @@ export const handlerMethods = {
     return value;
   },
 
-  omitArg(args = {}, key) {
+  omitArgs(args = {}, keys) {
     const payload = { ...args };
-    delete payload[key];
+    for (const key of keys) {
+      delete payload[key];
+    }
     return payload;
   },
 
-  executeCreate(spec, args = {}) {
-    if (spec.createMode === 'run') {
-      return this.createRunWithFallback(args);
+  /**
+   * Extract the entity's query args (spec.queryArgs, e.g. branch) from tool args
+   * without knowing their names in the handlers.
+   */
+  splitQueryArgs(spec, args = {}) {
+    const queryArgs = spec.queryArgs || [];
+    const query = {};
+    const payloadArgs = { ...args };
+    for (const key of queryArgs) {
+      if (args[key] !== undefined) {
+        query[key] = args[key];
+        delete payloadArgs[key];
+      }
     }
-    if (spec.createMode === 'requirement') {
-      return this.createRequirement(args);
-    }
-    const payload = this[spec.payloadBuilder](args);
-    return this.createWrapped(spec.resource, spec.wrapperKey, payload);
+    return { query, payloadArgs };
   },
 
-  executeUpdate(spec, id, args = {}) {
+  pickQueryArgs(spec, args = {}) {
+    const { query } = this.splitQueryArgs(spec, args);
+    return query;
+  },
+
+  executeCreate(spec, args = {}, query = {}) {
+    if (spec.createMode === 'run') {
+      return this.createRunWithFallback(args, query);
+    }
+    if (spec.createMode === 'requirement') {
+      return this.createRequirement(args, query);
+    }
+    const payload = this[spec.payloadBuilder](args);
+    return this.createWrapped(spec.resource, spec.wrapperKey, payload, query);
+  },
+
+  executeUpdate(spec, id, args = {}, query = {}) {
     if (spec.updateMode === 'run') {
-      return this.updateRunWithFallback(id, args);
+      return this.updateRunWithFallback(id, args, query);
     }
     if (spec.updateMode === 'requirement') {
-      return this.updateRequirement(id, args);
+      return this.updateRequirement(id, args, query);
     }
     const payload = this[spec.payloadBuilder](args);
     if (spec.updateMethod === 'patch') {
-      return this.patchWrapped(spec.resource, id, spec.wrapperKey, payload);
+      return this.patchWrapped(spec.resource, id, spec.wrapperKey, payload, query);
     }
-    return this.updateWrapped(spec.resource, id, spec.wrapperKey, payload);
+    return this.updateWrapped(spec.resource, id, spec.wrapperKey, payload, query);
   },
 };

--- a/src/mcp/registry/listings.js
+++ b/src/mcp/registry/listings.js
@@ -6,6 +6,7 @@ export const listingMethods = {
     count,
     group_by: groupBy,
     slim,
+    branch,
   } = {}) {
     return this.apiClient.list('tests', {
       page,
@@ -14,10 +15,11 @@ export const listingMethods = {
       count,
       group_by: groupBy,
       slim,
+      branch,
     });
   },
 
-  listSuites({ page, per_page: perPage, file_type: fileType, tag, labels, search_text: searchText, count, group_by: groupBy, slim } = {}) {
+  listSuites({ page, per_page: perPage, file_type: fileType, tag, labels, search_text: searchText, count, group_by: groupBy, slim, branch } = {}) {
     return this.apiClient.list('suites', {
       page,
       per_page: perPage,
@@ -28,6 +30,7 @@ export const listingMethods = {
       count,
       group_by: groupBy,
       slim,
+      branch,
     });
   },
 
@@ -38,6 +41,7 @@ export const listingMethods = {
     count,
     group_by: groupBy,
     slim,
+    branch,
   } = {}) {
     return this.apiClient.list('runs', {
       page,
@@ -46,6 +50,7 @@ export const listingMethods = {
       count,
       group_by: groupBy,
       slim,
+      branch,
     });
   },
 
@@ -137,6 +142,26 @@ export const listingMethods = {
 
   listTags({ count, group_by: groupBy, slim } = {}) {
     return this.apiClient.list('tags', { count, group_by: groupBy, slim });
+  },
+
+  listBranches({
+    page,
+    per_page: perPage,
+    filter_state: filterState,
+    filter_title: filterTitle,
+    count,
+    group_by: groupBy,
+    slim,
+  } = {}) {
+    return this.apiClient.list('branches', {
+      page,
+      per_page: perPage,
+      'filter[state]': filterState,
+      'filter[title]': filterTitle,
+      count,
+      group_by: groupBy,
+      slim,
+    });
   },
 
   getTagByTitle(tagId) {

--- a/src/mcp/registry/payloads.js
+++ b/src/mcp/registry/payloads.js
@@ -2,57 +2,58 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 
 export const payloadMethods = {
-  async createWrapped(resource, wrapperKey, payload) {
+  async createWrapped(resource, wrapperKey, payload, query = {}) {
     const wrappedBody = { [wrapperKey]: payload };
     try {
-      return await this.apiClient.create(resource, payload);
+      return await this.apiClient.create(resource, payload, query);
     } catch (error) {
       if (!this.shouldRetryWrappedBody(error, wrapperKey)) {
         throw error;
       }
-      return this.apiClient.create(resource, wrappedBody);
+      return this.apiClient.create(resource, wrappedBody, query);
     }
   },
 
-  async updateWrapped(resource, id, wrapperKey, payload) {
+  async updateWrapped(resource, id, wrapperKey, payload, query = {}) {
     const wrappedBody = { [wrapperKey]: payload };
     try {
-      return await this.apiClient.update(resource, id, payload);
+      return await this.apiClient.update(resource, id, payload, query);
     } catch (error) {
       if (!this.shouldRetryWrappedBody(error, wrapperKey)) {
         throw error;
       }
-      return this.apiClient.update(resource, id, wrappedBody);
+      return this.apiClient.update(resource, id, wrappedBody, query);
     }
   },
 
-  async patchWrapped(resource, id, wrapperKey, payload) {
+  async patchWrapped(resource, id, wrapperKey, payload, query = {}) {
     const wrappedBody = { [wrapperKey]: payload };
     try {
-      return await this.apiClient.patch(resource, id, payload);
+      return await this.apiClient.patch(resource, id, payload, query);
     } catch (error) {
       if (!this.shouldRetryWrappedBody(error, wrapperKey)) {
         throw error;
       }
-      return this.apiClient.patch(resource, id, wrappedBody);
+      return this.apiClient.patch(resource, id, wrappedBody, query);
     }
   },
 
-  async createRequirement(args = {}) {
+  async createRequirement(args = {}, query = {}) {
     const { files, ...payloadArgs } = args;
     const payload = this.buildRequirementPayload(payloadArgs);
 
     if (this.hasFiles(files)) {
       return this.apiClient.createMultipart(
         'requirements',
-        await this.buildRequirementFormData(payload, files)
+        await this.buildRequirementFormData(payload, files),
+        query
       );
     }
 
-    return this.createWrapped('requirements', 'requirement', payload);
+    return this.createWrapped('requirements', 'requirement', payload, query);
   },
 
-  async updateRequirement(requirementId, args = {}) {
+  async updateRequirement(requirementId, args = {}, query = {}) {
     const { files, ...payloadArgs } = args;
     const payload = this.buildRequirementPayload(payloadArgs);
 
@@ -60,11 +61,12 @@ export const payloadMethods = {
       return this.apiClient.patchMultipart(
         'requirements',
         requirementId,
-        await this.buildRequirementFormData(payload, files)
+        await this.buildRequirementFormData(payload, files),
+        query
       );
     }
 
-    return this.patchWrapped('requirements', requirementId, 'requirement', payload);
+    return this.patchWrapped('requirements', requirementId, 'requirement', payload, query);
   },
 
   hasFiles(files) {
@@ -198,27 +200,27 @@ export const payloadMethods = {
     };
   },
 
-  async createRunWithFallback(args = {}) {
+  async createRunWithFallback(args = {}, query = {}) {
     const payload = this.buildRunCreatePayload(args);
     try {
-      return await this.apiClient.create('runs', payload);
+      return await this.apiClient.create('runs', payload, query);
     } catch (error) {
       if (!this.shouldRetryWrappedBody(error, 'run')) {
         throw error;
       }
-      return this.apiClient.create('runs', { run: payload });
+      return this.apiClient.create('runs', { run: payload }, query);
     }
   },
 
-  async updateRunWithFallback(runId, args = {}) {
+  async updateRunWithFallback(runId, args = {}, query = {}) {
     const payload = this.buildRunUpdatePayload(args);
     try {
-      return await this.apiClient.update('runs', runId, payload);
+      return await this.apiClient.update('runs', runId, payload, query);
     } catch (error) {
       if (!this.shouldRetryWrappedBody(error, 'run')) {
         throw error;
       }
-      return this.apiClient.update('runs', runId, { run: payload });
+      return this.apiClient.update('runs', runId, { run: payload }, query);
     }
   },
 
@@ -350,5 +352,9 @@ export const payloadMethods = {
       global,
       confluence_url: confluenceUrl,
     };
+  },
+
+  buildBranchPayload({ title } = {}) {
+    return { title };
   },
 };

--- a/src/mcp/tool-definitions.js
+++ b/src/mcp/tool-definitions.js
@@ -14,6 +14,7 @@ import { ISSUES_TOOLS } from './definitions/issues.js';
 import { PLANS_TOOLS } from './definitions/plans.js';
 import { REQUIREMENTS_TOOLS } from './definitions/requirements.js';
 import { ATTACHMENT_TOOLS } from './definitions/attachments.js';
+import { BRANCHES_TOOLS } from './definitions/branches.js';
 import { withListOptions, withCountGroupOptions } from './list-projection.js';
 
 export const TOOL_DEFINITIONS = withCountGroupOptions(withListOptions([
@@ -33,4 +34,5 @@ export const TOOL_DEFINITIONS = withCountGroupOptions(withListOptions([
   ...ATTACHMENT_TOOLS,
   ...PLANS_TOOLS,
   ...REQUIREMENTS_TOOLS,
+  ...BRANCHES_TOOLS,
 ]));


### PR DESCRIPTION
## Summary

https://github.com/testomatio/app/issues/1644

  - **Branch management tools**: `branches_list`, `branches_get`, `branches_create`, `branches_update`, `branches_delete` (requires the `branches` enterprise feature)
  - **Branch scoping**: optional `branch` param (slug) added to all 15 tests/suites/runs CRUD tools
    - tests & suites — branch-local records, fork-on-write isolation
    - runs — tagged with the branch
    - omitted `branch` → default main-branch behavior, fully backward compatible