### PR TITLE
Add analytics charts MCP tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,9 @@ Included tools:
 
 - `analytics_tests` - `GET /api/v2/{project_id}/analytics/tests/{kind}`
 - `analytics_stats` - `GET /api/v2/{project_id}/analytics/stats/{kind}`
+- `analytics_charts_list` - `GET /api/v2/{project_id}/analytics/charts`
+- `analytics_charts_get` - `GET /api/v2/{project_id}/analytics/charts/{id}`
+- `analytics_charts_results` - `GET /api/v2/{project_id}/analytics/charts/{id}/result`
 
 Analytics endpoints require the `api_analytics` subscription feature. Use `q` as the TQL filter parameter for analytics tools.
 
@@ -350,6 +353,22 @@ Example `analytics_stats` call:
     "q": "tag IN ['@smoke']",
     "from": "2026-04-01",
     "to": "2026-04-30"
+  }
+}
+```
+
+`analytics_charts_get` returns a chart definition with its TQL queries; `analytics_charts_results`
+returns per-query totals or the matching tests/runs of one query (by its zero-based `number`).
+
+Example `analytics_charts_results` call:
+
+```json
+{
+  "name": "analytics_charts_results",
+  "arguments": {
+    "chart_id": "abc123",
+    "number": 2,
+    "per_page": 50
   }
 }
 ```

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1715,3 +1715,106 @@ Use `q` as the TQL filter parameter. The API parameter name is `q`, not `tql`.
 ```
 
 **API Endpoint:** `GET /api/v2/{project_id}/analytics/stats/{kind}`
+
+---
+
+### analytics_charts_list
+
+List saved analytics charts and queries. Each item bundles one or more TQL queries under a single
+title, optionally rendered as a chart (e.g. "pie") or kept as a plain saved query.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| has_chart | boolean | No | `true` — only items with a chart type set; `false` — only plain saved queries |
+| kind | string | No | Filter by context: `tests` or `runs` |
+| my_charts | boolean | No | When `true`, only items created by the authenticated user |
+| only_widgets | boolean | No | When `true`, only items marked as dashboard widgets |
+| page | integer | No | Page number |
+| per_page | integer | No | Items per page (1–100) |
+
+**Example:**
+```json
+{
+  "name": "analytics_charts_list",
+  "arguments": {
+    "kind": "tests",
+    "has_chart": true,
+    "page": 1,
+    "per_page": 20
+  }
+}
+```
+
+**API Endpoint:** `GET /api/v2/{project_id}/analytics/charts`
+
+---
+
+### analytics_charts_get
+
+Get a saved chart or query definition: title, chart type, context (tests/runs), and the ordered
+TQL queries that make it up.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| chart_id | string | Yes | Chart public UID |
+
+**Example:**
+```json
+{
+  "name": "analytics_charts_get",
+  "arguments": {
+    "chart_id": "abc123"
+  }
+}
+```
+
+**Returns:** chart `id`, `title`, `context`, `chart` display type (or null for a plain saved
+query), `queries: [{ number, query, title, label, color }]`, `options`, and the `url` to view
+the chart in Testomat.io.
+
+**API Endpoint:** `GET /api/v2/{project_id}/analytics/charts/{id}`
+
+---
+
+### analytics_charts_results
+
+Get the current results of a saved chart.
+
+Without `number`, returns the match count for every query in the chart — a cheap way to render
+a chart's totals. With `number` (zero-based query index), returns the matching tests or runs
+for that query, paginated.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| chart_id | string | Yes | Chart public UID |
+| number | integer | No | Zero-based query index to fetch full results for; omit for per-query totals |
+| page | integer | No | Page number (with `number`) |
+| per_page | integer | No | Items per page, 1–100 (with `number`) |
+
+**Example — totals for every query:**
+```json
+{
+  "name": "analytics_charts_results",
+  "arguments": {
+    "chart_id": "abc123"
+  }
+}
+```
+
+**Example — matching tests of the third query:**
+```json
+{
+  "name": "analytics_charts_results",
+  "arguments": {
+    "chart_id": "abc123",
+    "number": 2,
+    "page": 1,
+    "per_page": 50
+  }
+}
+```
+
+**API Endpoint:** `GET /api/v2/{project_id}/analytics/charts/{id}/result`

--- a/packages/enterprise/README.md
+++ b/packages/enterprise/README.md
@@ -6,6 +6,9 @@ This package includes all tools from `@testomatio/mcp` plus enterprise analytics
 
 - `analytics_tests`
 - `analytics_stats`
+- `analytics_charts_list`
+- `analytics_charts_get`
+- `analytics_charts_results`
 
 ## Installation
 

--- a/packages/enterprise/src/analytics.js
+++ b/packages/enterprise/src/analytics.js
@@ -130,7 +130,90 @@ export const ANALYTICS_TOOLS = withListOptions([
       additionalProperties: false,
     },
   },
-], { extraNames: ['analytics_tests'] });
+  {
+    name: 'analytics_charts_list',
+    description:
+      'Enterprise analytics: list saved analytics charts and queries (/api/v2/{project_id}/analytics/charts). Each item bundles one or more TQL queries under a single title, optionally rendered as a chart. Requires api_analytics subscription feature.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        has_chart: {
+          type: 'boolean',
+          description: 'When true, only items with a chart type set; when false, only plain saved queries with no chart.',
+        },
+        kind: {
+          type: 'string',
+          enum: ['tests', 'runs'],
+          description: 'Filter by context: charts over tests or over runs.',
+        },
+        my_charts: {
+          type: 'boolean',
+          description: 'When true, only items created by the authenticated user.',
+        },
+        only_widgets: {
+          type: 'boolean',
+          description: 'When true, only items marked as dashboard widgets.',
+        },
+        page: {
+          type: 'integer',
+          minimum: 1,
+        },
+        per_page: {
+          type: 'integer',
+          minimum: 1,
+          maximum: 100,
+        },
+      },
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'analytics_charts_get',
+    description:
+      'Enterprise analytics: get a saved chart or query definition — title, chart type, context, and the ordered TQL queries that make it up (/api/v2/{project_id}/analytics/charts/{id}). Requires api_analytics subscription feature.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        chart_id: {
+          type: 'string',
+          description: 'Chart public UID.',
+        },
+      },
+      required: ['chart_id'],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'analytics_charts_results',
+    description:
+      'Enterprise analytics: current results of a saved chart (/api/v2/{project_id}/analytics/charts/{id}/result). Without `number`, returns the match count for every query in the chart; with `number` (zero-based query index), returns the matching tests or runs for that query, paginated. Requires api_analytics subscription feature.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        chart_id: {
+          type: 'string',
+          description: 'Chart public UID.',
+        },
+        number: {
+          type: 'integer',
+          minimum: 0,
+          description: 'Zero-based index of the query within the chart to fetch full results for. Omit to get totals for all queries instead.',
+        },
+        page: {
+          type: 'integer',
+          minimum: 1,
+        },
+        per_page: {
+          type: 'integer',
+          minimum: 1,
+          maximum: 100,
+        },
+      },
+      required: ['chart_id'],
+      additionalProperties: false,
+    },
+  },
+], { extraNames: ['analytics_tests', 'analytics_charts_results'] });
 
 export const ENTERPRISE_TOOL_DEFINITIONS = [
   ...TOOL_DEFINITIONS,
@@ -147,6 +230,34 @@ export function registerAnalyticsHandlers(handlers) {
       })
     );
   handlers.analytics_stats = async (args = {}) => this.asText(await analyticsStats.call(this, args));
+
+  handlers.analytics_charts_list = async (args = {}) => {
+    const { verbose, fields, ...listArgs } = args;
+    return this.asText(
+      slimList(await analyticsChartsList.call(this, listArgs), {
+        verbose,
+        fields,
+        entity: 'analytics_charts',
+      })
+    );
+  };
+
+  handlers.analytics_charts_get = async (args = {}) => {
+    const id = this.pickRequiredArg(args, 'chart_id');
+    return this.asText(await this.apiClient.get('analytics/charts', id));
+  };
+
+  handlers.analytics_charts_results = async (args = {}) => {
+    const { verbose, fields, ...restArgs } = args;
+    const payload = await analyticsChartResults.call(this, restArgs);
+    return this.asText(
+      slimList(payload, {
+        verbose,
+        fields,
+        entity: 'analytics_chart_results',
+      })
+    );
+  };
 }
 
 function analyticsTests({
@@ -189,5 +300,25 @@ function analyticsStats({ kind, q, days, from, to, envs } = {}) {
     from,
     to,
     envs,
+  });
+}
+
+function analyticsChartsList({ has_chart, kind, my_charts, only_widgets, page, per_page: perPage } = {}) {
+  return this.apiClient.list('analytics/charts', {
+    has_chart,
+    kind,
+    my_charts,
+    only_widgets,
+    page,
+    per_page: perPage,
+  });
+}
+
+function analyticsChartResults({ chart_id, number, page, per_page: perPage } = {}) {
+  const id = this.pickRequiredArg({ chart_id }, 'chart_id');
+  return this.apiClient.list(`analytics/charts/${id}/result`, {
+    number,
+    page,
+    per_page: perPage,
   });
 }

--- a/src/mcp/list-projection.js
+++ b/src/mcp/list-projection.js
@@ -18,6 +18,8 @@ const HEAVY_FIELDS_BY_ENTITY = {
   plans: new Set(['description']),
   requirements: new Set(['description']),
   analytics_tests: new Set(['description', 'code', 'cleanTitle', 'publicTitle']),
+  analytics_charts: new Set(['description']),
+  analytics_chart_results: new Set(['description', 'code', 'cleanTitle', 'publicTitle']),
 };
 
 function isNullish(value) {


### PR DESCRIPTION
## Summary

Exposes saved analytics charts through MCP tools in `@testomatio/mcp-enterprise`, wrapping the new backend endpoints:
https://github.com/testomatio/app/issues/1648
  - `analytics_charts_list` — `GET /api/v2/{project_id}/analytics/charts` (filters: `has_chart`, `kind`, `my_charts`, `only_widgets` + pagination)
  - `analytics_charts_get` — `GET /api/v2/{project_id}/analytics/charts/{id}` (chart definition: title, type, TQL queries)
  - `analytics_charts_results` — `GET /api/v2/{project_id}/analytics/charts/{id}/result` (per-query totals without `number`; matching tests/runs with `number`, paginated)